### PR TITLE
Reserve space in hashmap

### DIFF
--- a/contrib/dynamic_embedding/src/tde/details/naive_id_transformer_impl.h
+++ b/contrib/dynamic_embedding/src/tde/details/naive_id_transformer_impl.h
@@ -53,7 +53,9 @@ template <typename Tag, typename T>
 inline NaiveIDTransformer<Tag, T>::NaiveIDTransformer(
     int64_t num_embedding,
     int64_t embedding_offset)
-    : embedding_offset_(embedding_offset), bitmap_(num_embedding) {}
+    : embedding_offset_(embedding_offset), bitmap_(num_embedding) {
+  global_id2cache_value_.reserve(num_embedding);
+}
 
 template <typename Tag, typename T>
 template <typename Filter, typename Update, typename Fetch>


### PR DESCRIPTION
This will accelerate naive transformer from：
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_NaiveIDTransformer_Cold/iterations:100        116 ms          116 ms          100
BM_NaiveIDTransformer_Hot/iterations:100        19.0 ms         19.0 ms          100
```
to
```
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
BM_NaiveIDTransformer_Cold/iterations:100       59.8 ms         59.8 ms          100
BM_NaiveIDTransformer_Hot/iterations:100        32.2 ms         32.2 ms          100
```
(The time of the Hot benchmark increases because the origin test will only have a hashmap of 1e6).