### PR TITLE
Add IDTransformerGroup to manage all tables in a model

### DIFF
--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/__init__.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/__init__.py
@@ -1,5 +1,6 @@
 from .dataloader import DataLoader
 from .id_transformer import IDTransformer
 from .id_transformer_collection import IDTransformerCollection
-from .ps import get_ps, PS, PSCollection
+from .id_transformer_group import IDTransformerGroup
+from .ps import PS, PSCollection
 from .tensor_list import TensorList


### PR DESCRIPTION
增加了 `IDTransformerGroup` 这层抽象。现在 python 这边的抽象逻辑是这样的：

- `PS`: 一个 table 连接的 PS table；
- `PSCollection`: 一个 `EmbeddingCollection` 或 `EmbeddingBagCollection` 对应的 PS table 们；

- `IDTransformer`: 对应一个实际的 embedding table；
- `IDTransformerCollection`: 对应一个 `EmbeddingCollection` 或 `EmbeddingBagCollection`，引入这层抽象的原因是一个 `EmbeddingCollection` 可以包含了多个 table。还负责处理 fetch 和 evction，所以其包含对应的 `PSCollection`。

- **新增** `IDTransformerGroup`: 包括了整个模型的所有 `EmbeddingCollection` 和 `EmbeddingBagCollection` 对应的 id transformer 以及 PS。

使用方式类似于：
```python
class Model(nn.Module):
    def __init__(self, config1, config2):
        super().__init__()
        self.emb1 = EmbeddingCollection(tables=config1, device=torch.device("meta"))
        self.emb2 = EmbeddingCollection(tables=config2, device=torch.device("meta"))
        ...

    def forward(self, kjt1, kjt2):
        ...

m = Model(config1, config2)
m = DistributedModelParallel(m)
transformers = IDTransformerGroup(
    m,
    {
        "emb1": config1,
        "emb2": config2,
    },
    ps_configs={
        "num_optimizer_stats": 2,
        "schema": "memory://"
    })

for kjt1, kjt2 in dataset:
    kjts = transformers.transform({
        "emb1": kjt1,
        "emb2": kjt2,
    })
    kjt1, kjt2 = kjts["emb1"], kjts["emb2"]
    output = m(kjt1, kjt2)
    ...
```