### PR TITLE
Add asynchronous fetch

### DIFF
--- a/contrib/dynamic_embedding/src/tde/bind.cpp
+++ b/contrib/dynamic_embedding/src/tde/bind.cpp
@@ -38,8 +38,8 @@ TORCH_LIBRARY(tde, m) {
       }))
       .def("append", &LocalShardList::emplace_back);
 
-  m.class_<Notification>("Notification")
-      .def("wait", &Notification::Wait);
+  m.class_<FetchHandle>("FetchHandle")
+      .def("wait", &FetchHandle::Wait);
 
   m.class_<PS>("PS")
       .def(torch::init<std::string, c10::intrusive_ptr<LocalShardList>, int64_t, int64_t, std::string>())

--- a/contrib/dynamic_embedding/src/tde/bind.cpp
+++ b/contrib/dynamic_embedding/src/tde/bind.cpp
@@ -1,7 +1,8 @@
+#include <torch/torch.h>
+
 #include "tde/id_transformer.h"
 #include "tde/ps.h"
 
-#include "torch/torch.h"
 namespace tde {
 TORCH_LIBRARY(tde, m) {
   details::IORegistry::RegisterAllDefaultIOs();
@@ -36,6 +37,9 @@ TORCH_LIBRARY(tde, m) {
         return c10::make_intrusive<LocalShardList>();
       }))
       .def("append", &LocalShardList::emplace_back);
+
+  m.class_<Notification>("Notification")
+      .def("wait", &Notification::Wait);
 
   m.class_<PS>("PS")
       .def(torch::init<std::string, c10::intrusive_ptr<LocalShardList>, int64_t, int64_t, std::string>())

--- a/contrib/dynamic_embedding/src/tde/notification.h
+++ b/contrib/dynamic_embedding/src/tde/notification.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <torch/torch.h>
+#include "tde/details/notification.h"
+
+namespace tde {
+
+class Notification : public torch::CustomClassHolder {
+ public:
+  void Done() { return notification_.Done(); }
+  void Wait() { return notification_.Wait(); }
+
+ private:
+  details::Notification notification_;
+};
+
+} // namespace tde

--- a/contrib/dynamic_embedding/src/tde/ps.cpp
+++ b/contrib/dynamic_embedding/src/tde/ps.cpp
@@ -3,19 +3,20 @@
 
 namespace tde {
 
-c10::intrusive_ptr<Notification> PS::Fetch(
+c10::intrusive_ptr<FetchHandle> PS::Fetch(
     torch::Tensor ids_to_fetch,
+    int64_t time,
     bool reinit,
     double weight_init_min,
     double weight_init_max) {
   TORCH_CHECK(ids_to_fetch.dim() == 2);
   std::vector<int64_t> col_ids{0};
   Filter(ids_to_fetch);
-  c10::intrusive_ptr<Notification> notification = c10::make_intrusive<Notification>();
   if (cache_ids_to_fetch_or_evict_.empty()) {
-    notification->Done();
-    return notification;
+    return c10::make_intrusive<FetchHandle>(time, c10::intrusive_ptr<PS>());
   }
+  fetch_notifications_.emplace_back(time, c10::make_intrusive<Notification>());
+  c10::intrusive_ptr<Notification> notification = fetch_notifications_.back().second;
   uint32_t num_os_ids = os_ids_.size();
   io_.Pull(
       table_name_,
@@ -47,7 +48,10 @@ c10::intrusive_ptr<Notification> PS::Fetch(
         }
         notification->Done();
       });
-  return notification;
+  // `unsafe_reclain_from_nonowning` is the `instrusive_ptr` version of `enable_shared_from_this`
+  return c10::make_intrusive<FetchHandle>(
+      time,
+      c10::intrusive_ptr<PS>::unsafe_reclaim_from_nonowning(this));
 }
 
 void PS::Filter(const torch::Tensor& tensor) {
@@ -69,6 +73,9 @@ void PS::Filter(const torch::Tensor& tensor) {
 
 void PS::Evict(torch::Tensor ids_to_evict) {
   TORCH_CHECK(ids_to_evict.dim() == 2);
+  // make sure all previous fetches are done.
+  SyncFetch();
+
   std::vector<int64_t> col_ids{0};
   // remove this copy!
   Filter(ids_to_evict);
@@ -112,6 +119,17 @@ void PS::Evict(torch::Tensor ids_to_evict) {
       [&notification] { notification.Done(); });
 
   notification.Wait();
+}
+
+void PS::SyncFetch(int64_t time) {
+  while (!fetch_notifications_.empty()) {
+    auto& [t, notification] = fetch_notifications_.front();
+    if (t != time && time >= 0) {
+      break;
+    }
+    notification->Wait();
+    fetch_notifications_.pop_front();
+  }
 }
 
 std::vector<torch::Tensor> PS::GetTensorViews(int64_t cache_id) {

--- a/contrib/dynamic_embedding/src/tde/ps.h
+++ b/contrib/dynamic_embedding/src/tde/ps.h
@@ -2,6 +2,7 @@
 #include <torch/custom_class.h>
 #include <torch/torch.h>
 
+#include <deque>
 #include <utility>
 #include "tde/details/io.h"
 #include "tde/notification.h"
@@ -58,6 +59,8 @@ class LocalShardList : public torch::CustomClassHolder {
   Container shards_;
 };
 
+class FetchHandle;
+
 class PS : public torch::CustomClassHolder {
  public:
   PS(std::string table_name,
@@ -75,12 +78,15 @@ class PS : public torch::CustomClassHolder {
     }
   }
 
-  c10::intrusive_ptr<Notification> Fetch(
+  c10::intrusive_ptr<FetchHandle> Fetch(
       torch::Tensor ids_to_fetch,
+      int64_t time,
       bool reinit,
       double weight_init_min,
       double weight_init_max);
   void Evict(torch::Tensor ids_to_evict);
+
+  void SyncFetch(int64_t time = -1);
 
  private:
   std::vector<torch::Tensor> GetTensorViews(int64_t cache_id);
@@ -94,6 +100,20 @@ class PS : public torch::CustomClassHolder {
   int64_t col_size_;
   std::vector<uint32_t> os_ids_;
   details::IO io_;
+  std::deque<std::pair<int64_t, c10::intrusive_ptr<Notification>>> fetch_notifications_;
+};
+
+struct FetchHandle : public torch::CustomClassHolder {
+ public:
+  FetchHandle(int64_t time, c10::intrusive_ptr<PS> ps) : time_(time), ps_(std::move(ps)) {}
+  void Wait() {
+    if (ps_ != nullptr)
+      ps_->SyncFetch(time_);
+  }
+
+ private:
+  int64_t time_;
+  c10::intrusive_ptr<PS> ps_;  // not owned
 };
 
 } // namespace tde

--- a/contrib/dynamic_embedding/src/tde/ps.h
+++ b/contrib/dynamic_embedding/src/tde/ps.h
@@ -4,6 +4,7 @@
 
 #include <utility>
 #include "tde/details/io.h"
+#include "tde/notification.h"
 #include "tde/tensor_list.h"
 
 namespace tde {
@@ -74,7 +75,7 @@ class PS : public torch::CustomClassHolder {
     }
   }
 
-  void Fetch(
+  c10::intrusive_ptr<Notification> Fetch(
       torch::Tensor ids_to_fetch,
       bool reinit,
       double weight_init_min,

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/dataloader.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/dataloader.py
@@ -1,8 +1,13 @@
 import queue
 import threading
+from typing import Dict, List, Union
 
 import torch
 from torch.utils.data._utils import MP_STATUS_CHECK_INTERVAL
+from torchrec import EmbeddingBagConfig, EmbeddingConfig
+from torchrec.distributed.model_parallel import DistributedModelParallel
+
+from .id_transformer_group import IDTransformerGroup
 
 
 # Similar to torch.utils.data._utils.pin_memory._pin_memory_loop
@@ -52,10 +57,101 @@ class DataLoaderIter:
 
 
 class DataLoader:
-    def __init__(self, dataset, transform_fn, num_prefetch=0):
+    def __init__(
+        self,
+        module: DistributedModelParallel,
+        configs_dict: Dict[str, Union[List[EmbeddingBagConfig], List[EmbeddingConfig]]],
+        dataset,
+        *,
+        data_info: Dict[int, str],
+        ps_config,
+        eviction_config=None,
+        transform_config=None,
+        parallel=True,
+        num_prefetch=0,
+    ):
+        """
+        DataLoader to transform data from global id to cache id.
+
+        Args:
+            module: DMP module that need dynamic embedding.
+            configs_dict: a dictionary that maps the module path of the sharded module to its embedding
+                configs or embeddingbag configs. The plan of `module` should contain the module path
+                in `configs_dict`.
+            dataset: dataset to transform.
+            data_info: dict keyed by int index of module path. For example, if the dataset produces
+                `label, kjt1, kjt2` each iteration and `kjt1` and `kjt2` are inputs to modules of path
+                `emb1` and `emb2` respectively, then `data_info` should be `{ 1: "emb1", 2: "emb2" }`.
+            ps_config: configuration for PS. Required fields are "schema", which designates the schema of
+                the PS server, e.g. redis://192.168.3.1:3948 and "num_optimizer_stats", which tell PS server
+                how many optimizer states for the parameter, for intance, the value is 2 for Adam optimizer.
+            eviction_config: configuration for eviction policy. Default is `{"type": "mixed_lru_lfu"}`
+            transformer_config: configuration for the transformer. Default is `{"type": "naive"}`
+            parallel: Whether the IDTransformerCollections will run paralell. When set to True,
+                IDTransformerGroup will start a thread for each IDTransformerCollection.
+            num_prefetch: number of samples to prefetch.
+
+        Example:
+            class Model(nn.Module):
+                def __init__(self, config1, config2):
+                    super().__init__()
+                    self.emb1 = EmbeddingCollection(tables=config1, device=torch.device("meta"))
+                    self.emb2 = EmbeddingCollection(tables=config2, device=torch.device("meta"))
+                    ...
+
+                def forward(self, kjt1, kjt2):
+                    ...
+
+            m = Model(config1, config2)
+            m = DistributedModelParallel(m)
+            dataloader = DataLoader(
+                m,
+                { "emb1": config1, "emb2": config2 },
+                dataset,
+                data_info={ 1: "emb1", 2: "emb2" }
+                ps_configs={
+                    "num_optimizer_stats": 2,
+                    "schema": "memory://"
+                },
+                num_prefetch=1)
+
+            for label, kjt1, kjt2 in dataloader:
+                output = m(kjt1, kjt2)
+                ...
+        """
+        self._id_transformer_group = IDTransformerGroup(
+            module,
+            configs_dict,
+            ps_config=ps_config,
+            eviction_config=eviction_config,
+            transform_config=transform_config,
+            parallel=parallel,
+        )
+
+        for _, path in data_info.items():
+            if path not in self._id_transformer_group:
+                raise ValueError(
+                    f"invalid path `{path}` data_info. No id transformer for this path."
+                )
+
+        self._data_info = data_info
+
+        self._data_queue = queue.Queue(maxsize=num_prefetch)
+        self._done_event = threading.Event()
+
         self._dataset = dataset
-        self._transform_fn = transform_fn
         self._num_prefetch = num_prefetch
+
+    def _transform_fn(self, data):
+        """
+        transform data with `data_info`
+        """
+        global_kjts = {path: data[idx] for idx, path in self._data_info.items()}
+        cache_kjts = self._id_transformer_group.transform(global_kjts)
+        data = list(data)
+        for idx, path in self._data_info.items():
+            data[idx] = cache_kjts[path]
+        return tuple(data)
 
     def __iter__(self):
         return DataLoaderIter(

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer.py
@@ -28,15 +28,13 @@ class IDTransformer:
             }
         )
         self._transformer = torch.classes.tde.IDTransformer(num_embedding, config)
-        self._time = 0
 
-    def transform(self, global_ids: TensorList, cache_ids: TensorList):
+    def transform(self, global_ids: TensorList, cache_ids: TensorList, time: int):
         """
         Transform `global_ids` and store the results in `cache_ids`.
         """
-        self._time += 1
         return self._transformer.transform(
-            global_ids.tensor_list, cache_ids.tensor_list, self._time
+            global_ids.tensor_list, cache_ids.tensor_list, time
         )
 
     def evict(self, num_to_evict):

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer_collection.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer_collection.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List, Tuple, Union
 
 import torch
 from torchrec import EmbeddingBagConfig, EmbeddingConfig, KeyedJaggedTensor
@@ -58,9 +58,15 @@ class IDTransformerCollection:
         ]
         self._ever_evicted = False
 
-    def transform(self, global_features: KeyedJaggedTensor) -> KeyedJaggedTensor:
+    def transform(
+        self, global_features: KeyedJaggedTensor
+    ) -> Tuple[KeyedJaggedTensor, List[torch.classes.tde.Notification]]:
         """
         Transform global kjts into local kjts.
+
+        Return:
+            KeyedJaggedTensor: the transformed kjt.
+            List[torch.classes.tde.Notification]: list of fetch handles to wait.
         """
         global_values = global_features.values()
         cache_values = torch.empty_like(global_values)
@@ -70,6 +76,7 @@ class IDTransformerCollection:
         }
         offset_per_key = global_features.offset_per_key()
 
+        fetch_handles = []
         for i, transformer in enumerate(self._transformers):
             feature_names = self._feature_names[i]
             feature_indices = [
@@ -90,13 +97,18 @@ class IDTransformerCollection:
             if self._ps_collection is not None:
                 table_name = self._table_names[i]
                 ps = self._ps_collection[table_name]
-                if result.ids_to_fetch is not None:
-                    ps.fetch(
+                if result.ids_to_fetch.numel() > 0:
+                    handle = ps.fetch(
                         result.ids_to_fetch,
                         self._ever_evicted,
                         self._configs[i].get_weight_init_min(),
                         self._configs[i].get_weight_init_max(),
                     )
+                    if not result.success:
+                        # sync the fetch to make sure the potential rehash is correct.
+                        handle.wait()
+                    else:
+                        fetch_handles.append(handle)
                 if not result.success:
                     # TODO(zilinzhu): make this configurable
                     ids_to_evict = transformer.evict(transformer._num_embedding // 2)
@@ -113,11 +125,13 @@ class IDTransformerCollection:
                             f"Maybe the num_embedding of table {table_name} is too small?"
                         )
                     if result.ids_to_fetch is not None:
-                        ps.fetch(
-                            result.ids_to_fetch,
-                            self._ever_evicted,
-                            self._configs[i].get_weight_init_min(),
-                            self._configs[i].get_weight_init_max(),
+                        fetch_handles.append(
+                            ps.fetch(
+                                result.ids_to_fetch,
+                                self._ever_evicted,
+                                self._configs[i].get_weight_init_min(),
+                                self._configs[i].get_weight_init_max(),
+                            )
                         )
 
         cache_values = KeyedJaggedTensor(
@@ -126,4 +140,4 @@ class IDTransformerCollection:
             lengths=global_features.lengths(),
             weights=global_features.weights_or_none(),
         )
-        return cache_values
+        return cache_values, fetch_handles

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer_group.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer_group.py
@@ -131,7 +131,7 @@ class IDTransformerGroup:
             kjt_dict: dict keyed by module path of global kjts.
         Return:
             Dict[str, KeyedJaggedTensor]
-            List[torch.classes.tde.Notification]: list of fetch handles to wait.
+            List[torch.classes.tde.FetchHandle]: list of fetch handles to wait.
         """
         result = {}
         fetch_handles = []

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer_group.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/id_transformer_group.py
@@ -131,8 +131,10 @@ class IDTransformerGroup:
             kjt_dict: dict keyed by module path of global kjts.
         Return:
             Dict[str, KeyedJaggedTensor]
+            List[torch.classes.tde.Notification]: list of fetch handles to wait.
         """
         result = {}
+        fetch_handles = []
         if self._parallel:
             for path, kjt in kjt_dict.items():
                 if path not in self._id_transformer_collections:
@@ -143,7 +145,9 @@ class IDTransformerGroup:
                 self._input_queues[path].put(kjt)
 
             for path in kjt_dict:
-                result[path] = self._output_queues[path].get()
+                kjt, handles = self._output_queues[path].get()
+                result[path] = kjt
+                fetch_handles.extend(handles)
         else:
             for path, kjt in kjt_dict.items():
                 if path not in self._id_transformer_collections:
@@ -151,8 +155,10 @@ class IDTransformerGroup:
                         f"kjt_dict contain invalid path {path}. "
                         f"should be one of {self._id_transformer_collections.keys()}"
                     )
-                result[path] = self._id_transformer_collections[path].transform(kjt)
-        return result
+                kjt, handles = self._id_transformer_collections[path].transform(kjt)
+                result[path] = kjt
+                fetch_handles.extend(handles)
+        return result, fetch_handles
 
     def __contains__(self, path):
         """

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/ps.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/ps.py
@@ -80,7 +80,7 @@ class PS:
         Fetch `ids_to_fetch` from tensor. If `reinit` is set to `True`, will
         reinitialize the embedding if the global id is not in PS.
         """
-        self._ps.fetch(ids_to_fetch, reinit, weight_init_max, weight_init_min)
+        return self._ps.fetch(ids_to_fetch, reinit, weight_init_max, weight_init_min)
 
 
 class PSCollection:

--- a/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/ps.py
+++ b/contrib/dynamic_embedding/src/torchrec_dynamic_embedding/ps.py
@@ -72,6 +72,7 @@ class PS:
     def fetch(
         self,
         ids_to_fetch: torch.Tensor,
+        time: int,
         reinit: bool = False,
         weight_init_max: float = 0,
         weight_init_min: float = 0,
@@ -80,7 +81,9 @@ class PS:
         Fetch `ids_to_fetch` from tensor. If `reinit` is set to `True`, will
         reinitialize the embedding if the global id is not in PS.
         """
-        return self._ps.fetch(ids_to_fetch, reinit, weight_init_max, weight_init_min)
+        return self._ps.fetch(
+            ids_to_fetch, time, reinit, weight_init_max, weight_init_min
+        )
 
 
 class PSCollection:

--- a/contrib/dynamic_embedding/tests/test_id_transformer.py
+++ b/contrib/dynamic_embedding/tests/test_id_transformer.py
@@ -43,12 +43,12 @@ class TestIDTransformer(unittest.TestCase):
         python_transformer = PythonIdTransformer(num_embedding)
         global_ids = torch.empty(shape, dtype=torch.int64)
 
-        for _ in range(10):
+        for timestamp in range(10):
             global_ids.random_(0, 512)
             cache_ids = torch.empty_like(global_ids)
 
             result = transformer.transform(
-                TensorList([global_ids]), TensorList([cache_ids])
+                TensorList([global_ids]), TensorList([cache_ids]), timestamp
             )
             success, ids_to_fetch = result.success, result.ids_to_fetch
             self.assertTrue(success)
@@ -75,13 +75,13 @@ class TestIDTransformer(unittest.TestCase):
         global_ids = torch.tensor([1, 2, 3, 4], dtype=torch.long)
         cache_ids = torch.empty_like(global_ids)
         result = transformer.transform(
-            TensorList([global_ids]), TensorList([cache_ids])
+            TensorList([global_ids]), TensorList([cache_ids]), 0
         )
         self.assertTrue(result.success)
 
         global_ids = torch.tensor([1, 3, 5, 7], dtype=torch.long)
         result = transformer.transform(
-            TensorList([global_ids]), TensorList([cache_ids])
+            TensorList([global_ids]), TensorList([cache_ids]), 1
         )
         self.assertTrue(result.success)
 

--- a/contrib/dynamic_embedding/tests/test_id_transformer_collection.py
+++ b/contrib/dynamic_embedding/tests/test_id_transformer_collection.py
@@ -17,7 +17,9 @@ class TestIDTransformer(unittest.TestCase):
             values=torch.tensor([1, 3, 2, 3, 4, 3, 2]),
             lengths=torch.tensor([4, 3]),
         )
-        cache_kjt = transformer_collection.transform(global_kjt)
+        cache_kjt, fetch_handles = transformer_collection.transform(global_kjt)
+        for handle in fetch_handles:
+            handle.wait()
         self.assertEqual(cache_kjt.keys(), global_kjt.keys())
         self.assertTrue(torch.all(cache_kjt.lengths() == global_kjt.lengths()))
         self.assertTrue(
@@ -37,7 +39,9 @@ class TestIDTransformer(unittest.TestCase):
             values=torch.tensor([1, 3, 2, 3, 4, 3, 2, 3, 2, 1]),
             lengths=torch.tensor([4, 3, 3]),
         )
-        cache_kjt = transformer_collection.transform(global_kjt)
+        cache_kjt, fetch_handles = transformer_collection.transform(global_kjt)
+        for handle in fetch_handles:
+            handle.wait()
         self.assertEqual(cache_kjt.keys(), global_kjt.keys())
         self.assertTrue(torch.all(cache_kjt.lengths() == global_kjt.lengths()))
         self.assertTrue(

--- a/contrib/dynamic_embedding/tests/test_integral_precision.py
+++ b/contrib/dynamic_embedding/tests/test_integral_precision.py
@@ -120,7 +120,10 @@ class TestPSPrecision(unittest.TestCase):
                 values=torch.randint(0, 1000, (40,), dtype=torch.long),
                 lengths=torch.tensor([10, 10, 10, 10], dtype=torch.long),
             )
-            mapped_kjt = transformer.transform({"emb": kjt})["emb"]
+            kjts, fetch_handles = transformer.transform({"emb": kjt})
+            for handle in fetch_handles:
+                handle.wait()
+            mapped_kjt = kjts["emb"]
             label = torch.randint(0, 2, (4, 1), device=device).float()
             kjt = kjt.to(device)
             mapped_kjt = mapped_kjt.to(device)

--- a/contrib/dynamic_embedding/tests/test_ps.py
+++ b/contrib/dynamic_embedding/tests/test_ps.py
@@ -18,7 +18,7 @@ class TestPS(unittest.TestCase):
         ps = PS("table", [tensor], "memory://")
         ps.evict(ids)
         tensor[:, :] = 0
-        ps.fetch(ids)
+        ps.fetch(ids, 0).wait()
         self.assertTrue(torch.allclose(tensor[cache_ids], origin_tensor[cache_ids]))
 
     def testOS(self):
@@ -35,7 +35,7 @@ class TestPS(unittest.TestCase):
         tensor[:, :] = 0
         optim1[:, :] = 0
         optim2[:, :] = 0
-        ps.fetch(ids)
+        ps.fetch(ids, 0).wait()
         self.assertTrue(torch.allclose(tensor[cache_ids], origin_tensor[cache_ids]))
         self.assertTrue(torch.allclose(optim1[cache_ids], origin_optim1[cache_ids]))
         self.assertTrue(torch.allclose(optim2[cache_ids], origin_optim2[cache_ids]))
@@ -54,7 +54,7 @@ class TestPS(unittest.TestCase):
         fetch_ids = torch.tensor(
             [[100, 1], [101, 3], [102, 5], [103, 7]], dtype=torch.long
         )
-        ps.fetch(fetch_ids)
+        ps.fetch(fetch_ids, 0).wait()
         self.assertTrue(torch.allclose(tensor[new_cache_ids], origin_tensor[cache_ids]))
 
     def testFetchNonExist(self):
@@ -67,7 +67,7 @@ class TestPS(unittest.TestCase):
         tensor[:, :] = 0
         addition_cache_ids = [3, 9]
         additional_fetch_ids = torch.tensor([[103, 3], [104, 9]], dtype=torch.long)
-        ps.fetch(torch.cat([evict_ids, additional_fetch_ids]))
+        ps.fetch(torch.cat([evict_ids, additional_fetch_ids]), 0).wait()
         self.assertTrue(torch.allclose(tensor[cache_ids], origin_tensor[cache_ids]))
         self.assertTrue(
             torch.allclose(

--- a/contrib/dynamic_embedding/tests/test_ps_collection.py
+++ b/contrib/dynamic_embedding/tests/test_ps_collection.py
@@ -106,7 +106,9 @@ class TestPSCollection(unittest.TestCase):
             values=torch.tensor([1, 2, 3, 4, 1, 2]),
             lengths=torch.tensor([4, 2]),
         )
-        cache_kjt = transformer_collection.transform(global_kjt_1)
+        cache_kjt, fetch_handles = transformer_collection.transform(global_kjt_1)
+        for handle in fetch_handles:
+            handle.wait()
         embedding = model(cache_kjt.to(device))
         self.assertTrue(
             torch.all(cache_kjt.values() == torch.tensor([0, 1, 2, 3, 0, 1]))
@@ -129,7 +131,9 @@ class TestPSCollection(unittest.TestCase):
         )
 
         # this will evict 3 and 4
-        cache_kjt = transformer_collection.transform(global_kjt_2)
+        cache_kjt, fetch_handles = transformer_collection.transform(global_kjt_2)
+        for handle in fetch_handles:
+            handle.wait()
         embedding = model(cache_kjt.to(device))
         self.assertTrue(
             torch.all(cache_kjt.values() == torch.tensor([0, 1, 0, 2, 2, 3]))
@@ -152,7 +156,9 @@ class TestPSCollection(unittest.TestCase):
             values=torch.tensor([1, 2, 1, 4, 3, 4]),
             lengths=torch.tensor([3, 3]),
         )
-        cache_kjt = transformer_collection.transform(global_kjt_3)
+        cache_kjt, fetch_handles = transformer_collection.transform(global_kjt_3)
+        for handle in fetch_handles:
+            handle.wait()
         embedding = model(cache_kjt.to(device))
         self.assertTrue(
             torch.all(cache_kjt.values() == torch.tensor([0, 1, 0, 2, 3, 2]))


### PR DESCRIPTION
把 `PS::Fetch` 改成了异步的，并在 dataloader 取出数据的时候再进行 `handle.wait()`。

现在遇到的问题主要是 Evict 前是否应该把之前的所有 fetch 的 notification 都 wait 掉？比较担心前面迭代步的 fetch 在后面的 evict 之后才被完成。

但是如果要保存前面的所有的 fetch handle 的话，应该存在哪里呢？